### PR TITLE
Reduce the default maxDistance to 0.01%

### DIFF
--- a/differ/src/commonMain/kotlin/com/dropbox/differ/ImageComparator.kt
+++ b/differ/src/commonMain/kotlin/com/dropbox/differ/ImageComparator.kt
@@ -21,7 +21,7 @@ interface ImageComparator {
 }
 
 class SimpleImageComparator(
-  val maxDistance: Float = 0.1f,
+  val maxDistance: Float = 0.001f,
   val hShift: Int = 0,
   val vShift: Int = 0,
 ) : ImageComparator {


### PR DESCRIPTION
It's currently set to 10% which is a large amount of tolerance for a single pixel.