### PR TITLE
Fix SimpleImageComparator for different sized images

### DIFF
--- a/differ/src/commonMain/kotlin/com/dropbox/differ/ImageComparator.kt
+++ b/differ/src/commonMain/kotlin/com/dropbox/differ/ImageComparator.kt
@@ -29,6 +29,13 @@ class SimpleImageComparator(
     val width = maxOf(left.width, right.width)
     val height = maxOf(left.height, right.height)
 
+    if (diff != null) {
+      require(diff.size >= width * height) {
+        "The provided diff mask should be >= the size of the largest image to be compared. " +
+          "Mask size: ${diff.size}. Largest image size: ${width * height}."
+      }
+    }
+
     fun compareWindow(x: Int, y: Int, color: Color): Boolean {
       if (hShift == 0 && vShift == 0) return false
 
@@ -40,6 +47,9 @@ class SimpleImageComparator(
       (l..r).forEach { offsetX ->
         (b..t).forEach { offsetY ->
           if (offsetX != x || offsetY != y) {
+            // If we're out of bounds for either of the images, return false
+            if (x >= minOf(left.width, right.width) || y >= minOf(left.height, right.height)) return false
+
             val c1 = left.getPixel(offsetX, offsetY)
             val localDeltaThreshold = color.distance(c1)
 
@@ -56,14 +66,21 @@ class SimpleImageComparator(
     }
 
     var misses = 0
-    (0 until width).forEach { x ->
-      (0 until height).forEach { y ->
+    for (x in 0 until width) {
+      for (y in 0 until height) {
+        if (x >= minOf(left.width, right.width) || y >= minOf(left.height, right.height)) {
+          // If we're out bounds for either of the images, then we have a 100% miss.
+          // We can't call getPixel() below as it will would cause an out of bounds exception
+          misses++
+          diff?.setValue(x, y, 1f)
+          continue
+        }
+
         val leftColor = left.getPixel(x, y)
         val rightColor = right.getPixel(x, y)
 
         val delta = leftColor.distance(rightColor)
         if (delta > maxDistance) {
-
           // If exact pixels don't match, check within the shift window
           if (!compareWindow(x, y, leftColor)) {
             misses++

--- a/differ/src/commonTest/kotlin/com/dropbox/differ/SimpleImageComparatorTest.kt
+++ b/differ/src/commonTest/kotlin/com/dropbox/differ/SimpleImageComparatorTest.kt
@@ -4,6 +4,7 @@ import com.dropbox.differ.resources.TestImage
 import com.dropbox.differ.resources.mutate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class SimpleImageComparatorTest {
   @Test fun `returns no pixel differences for identical images`() {
@@ -29,6 +30,16 @@ class SimpleImageComparatorTest {
     assertEquals(first.width * first.height, result.pixelDifferences)
   }
 
+  @Test fun `returns DIFFERENT for different sized images`() {
+    val first = TestImage(width = 1080, height = 1080)
+    val second = TestImage(width = 1080, height = 540)
+
+    val comparator = SimpleImageComparator()
+    val result = comparator.compare(first, second)
+
+    assertEquals(540 * 1080, result.pixelDifferences)
+  }
+
   @Test fun `mask contains differences`() {
     val first = TestImage(width = 1080, height = 1920)
     val second = TestImage(width = 1080, height = 1920)
@@ -50,6 +61,18 @@ class SimpleImageComparatorTest {
         val expected = if (y in (950..970) && x in (530..550)) expectedDistance else 0.0f
         assertEquals(expected, actual, "Mask pixel at $x, $y")
       }
+    }
+  }
+
+  @Test
+  fun `incorrect sized mask throws exception`() {
+    assertFailsWith<IllegalArgumentException> {
+      val first = TestImage(width = 1080, height = 1080)
+      val second = TestImage(width = 1080, height = 1080)
+      val mask = Mask(width = 400, height = 400)
+
+      val comparator = SimpleImageComparator()
+      val result = comparator.compare(first, second, mask)
     }
   }
 }


### PR DESCRIPTION
If SimpleImageComparator is provided with two differently sized images, it throws an exception due to calling `getPixel()` on with out-of-bounds coordinates. This PR fixes that by adding some bounds checking to various places where `getPixel()` is called.

I also added some checking of the diff mask size, as it's currently possible to provide an incorrect sized mask, which would then cause an out-of-bounds exception too.