### PR TITLE
Use macos-latest to release ios artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Build and Test
-    runs-on: 'ubuntu-latest'
+    runs-on: 'macos-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Hello dropbox/differ team,

I noticed that iOS artifacts are not being released due to the use of ubuntu-latest in GitHub Actions. To address this, I propose switching to macos-latest for builds targeting iOS, which should enable the automated release of iOS-compatible binaries.

I've implemented this change in the pull request. Integrating it would significantly benefit iOS developers using Kotlin Multiplatform.

Thank you for considering this update.

https://central.sonatype.com/search?q=com.dropbox.differ