### PR TITLE
Bump github action artifact upload v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: (Fail-only) Upload the build report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: error-report
           path: build-reports.zip


### PR DESCRIPTION
After the merge of #17 it github action [upload-artifact](https://github.com/actions/upload-artifact) v2 has been deprecated causing the build to fail. This PR bumps the action version to v4