### PR TITLE
Publish all generated artifacts to maven central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,7 @@ jobs:
   publish:
     if: github.repository == 'dropbox/differ' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: [build]
-    strategy:
-      matrix:
-        include:
-          - release-target: publishIosArm64PublicationToMavenCentral
-            os: macos-latest
-          - release-target: publishJvmPublicationToMavenCentral
-            os: ubuntu-latest
-          - release-target: publishLinuxX64PublicationToMavenCentral
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,7 +66,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
-        run: ./gradlew ${{ matrix.release-target }}
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository # All publications should go to Maven Central
         if: success()
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Publish release
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository # All publications should go to Maven Central
+        run: ./gradlew publish # Publish all artifacts to all configured repositories. Maven Central for this project.
         if: success()
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
It appears we missed the artifacts for `iosX64()` and `iosSimulatorArm64()` targets. Only `iosArm64()` was resolving. In other to support all the artifacts, run the `./gradlew publish` to publish all of them to maven central repository.

Also @rharter we will need a public release( if you're ready for a 0.0.3 release) as we're only getting 0.0.3-SNAPSHOT from https://s01.oss.sonatype.org/content/repositories/snapshots/com/dropbox/differ/

cc @takahirom  
  